### PR TITLE
Fix broken inter-page links in documentation

### DIFF
--- a/astro-site/fix_all_links.py
+++ b/astro-site/fix_all_links.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Fix all broken inter-page links in the Astro/Starlight content files.
+
+Handles the following link patterns:
+  A) Bare markdown links:   [Text](r_foo)         → [Text](../r_foo)         (same category)
+                             [Text](r_foo)         → [Text](../rules/r_foo)   (cross category)
+  B) Absolute HTML links:   <a href="/rules/r_foo">Text</a> → [Text](../r_foo)
+  C) Bare HTML links:       <a href="R_mechs">text</a>     → [text](../rules/r_mechs)
+  D) Existing cross-cat relative links: normalize slug case to lowercase
+
+All link targets are normalized to lowercase.
+Stray HTML tags (e.g. </sub>) in converted link text are cleaned up.
+
+Usage:
+  python fix_all_links.py              # Apply fixes
+  python fix_all_links.py --dry-run    # Preview changes without writing
+  python fix_all_links.py --validate   # Check that all link targets resolve to real files
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+DOCS_ROOT = Path(__file__).parent / "src" / "content" / "docs"
+
+# Map slug prefix → content directory
+PREFIX_TO_DIR = {
+    "r_": "rules",
+    "f_": "factions",
+    "c_": "components",
+}
+
+
+def get_category(filepath: Path) -> str | None:
+    """Get the category directory of a file (rules, factions, components)."""
+    rel = filepath.relative_to(DOCS_ROOT)
+    parts = rel.parts
+    if len(parts) >= 2:
+        return parts[0]  # e.g., 'rules', 'factions', 'components'
+    return None
+
+
+def slug_to_category(slug: str) -> str | None:
+    """Determine the target category directory from a slug's prefix."""
+    slug_lower = slug.lower()
+    for prefix, category in PREFIX_TO_DIR.items():
+        if slug_lower.startswith(prefix):
+            return category
+    return None
+
+
+def build_valid_slugs() -> set[str]:
+    """Build a set of valid lowercase slugs from actual content files."""
+    slugs = set()
+    for category_dir in ["rules", "factions", "components"]:
+        dir_path = DOCS_ROOT / category_dir
+        if dir_path.exists():
+            for f in dir_path.iterdir():
+                if f.suffix == ".md":
+                    slugs.add(f.stem.lower())
+    return slugs
+
+
+def compute_relative_path(source_category: str, target_category: str, target_slug: str) -> str:
+    """
+    Compute the relative markdown link path from a source file to a target.
+
+    Each page lives at /<category>/<slug>/ (directory-style), so we always
+    need ../ to escape the current page's directory, then either land in
+    a sibling (same category) or navigate to another category directory.
+    """
+    target_slug = target_slug.lower()
+    if source_category == target_category:
+        # Same directory: ../r_foo
+        return f"../{target_slug}"
+    else:
+        # Cross directory: ../rules/r_foo
+        return f"../{target_category}/{target_slug}"
+
+
+def clean_inner_html(text: str) -> str:
+    """Clean up stray HTML tags from converted link text."""
+    # Remove stray </sub> tags (present in some technology links)
+    text = re.sub(r"</sub>", "", text)
+    # Strip leading/trailing whitespace
+    return text.strip()
+
+
+def fix_file(filepath: Path, valid_slugs: set[str], dry_run: bool = False) -> list[str]:
+    """Fix all links in a single file. Returns list of change descriptions."""
+    changes = []
+    source_category = get_category(filepath)
+
+    if source_category is None:
+        return []
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    new_content = content
+
+    # ──────────────────────────────────────────────────────────────
+    # Pattern A: Bare markdown links — [Text](r_foo) or [Text](R_foo)
+    # Matches slug-only targets (no ../, no /, no http)
+    # ──────────────────────────────────────────────────────────────
+    def fix_bare_md_link(match):
+        full_match = match.group(0)
+        text = match.group(1)
+        target = match.group(2)
+        target_lower = target.lower()
+        target_cat = slug_to_category(target_lower)
+        if target_cat and target_lower in valid_slugs:
+            new_path = compute_relative_path(source_category, target_cat, target_lower)
+            changes.append(f"  MD bare:  [{text}]({target}) → [{text}]({new_path})")
+            return f"[{text}]({new_path})"
+        return full_match
+
+    bare_md_pattern = re.compile(r"\[([^\]]+)\]\(([RrFfCc]_[A-Za-z0-9_]+)\)")
+    new_content = bare_md_pattern.sub(fix_bare_md_link, new_content)
+
+    # ──────────────────────────────────────────────────────────────
+    # Pattern B: Absolute HTML links — <a href="/rules/r_foo">Text</a>
+    # Converts to markdown link with correct relative path
+    # ──────────────────────────────────────────────────────────────
+    def fix_absolute_html_link(match):
+        full_match = match.group(0)
+        abs_path = match.group(1)       # e.g., /rules/r_technology_sc
+        inner_text = match.group(2)     # may contain <abbr> etc.
+
+        # Parse the absolute path: /category/slug
+        parts = abs_path.strip("/").split("/")
+        if len(parts) == 2:
+            target_cat_name = parts[0]
+            target_slug = parts[1].lower()
+            if target_slug in valid_slugs:
+                new_path = compute_relative_path(source_category, target_cat_name, target_slug)
+                cleaned_text = clean_inner_html(inner_text)
+                changes.append(
+                    f"  HTML abs: <a href=\"{abs_path}\">...</a> → [{cleaned_text}]({new_path})"
+                )
+                return f"[{cleaned_text}]({new_path})"
+        return full_match
+
+    # Match <a href="/...">...</a> — href starts with /
+    abs_html_pattern = re.compile(r'<a href="(/[^"]+)">(.*?)</a>', re.DOTALL)
+    new_content = abs_html_pattern.sub(fix_absolute_html_link, new_content)
+
+    # ──────────────────────────────────────────────────────────────
+    # Pattern C: Bare HTML links — <a href="R_mechs">text</a>
+    # Converts to markdown link with correct relative path
+    # ──────────────────────────────────────────────────────────────
+    def fix_bare_html_link(match):
+        full_match = match.group(0)
+        target = match.group(1)         # e.g., R_mechs
+        inner_text = match.group(2)
+
+        target_lower = target.lower()
+        target_cat = slug_to_category(target_lower)
+        if target_cat and target_lower in valid_slugs:
+            new_path = compute_relative_path(source_category, target_cat, target_lower)
+            cleaned_text = clean_inner_html(inner_text)
+            changes.append(
+                f"  HTML bare: <a href=\"{target}\">...</a> → [{cleaned_text}]({new_path})"
+            )
+            return f"[{cleaned_text}]({new_path})"
+        return full_match
+
+    # Match <a href="X_slug">...</a> where X is R/F/C (any case)
+    bare_html_pattern = re.compile(r'<a href="([RrFfCc]_[A-Za-z0-9_]+)">(.*?)</a>', re.DOTALL)
+    new_content = bare_html_pattern.sub(fix_bare_html_link, new_content)
+
+    # ──────────────────────────────────────────────────────────────
+    # Pattern D: Existing cross-category relative links — normalize case
+    # e.g., ](../factions/F_creuss) → ](../factions/f_creuss)
+    # ──────────────────────────────────────────────────────────────
+    def fix_existing_relative_link(match):
+        text = match.group(1)
+        category = match.group(2)
+        slug = match.group(3)
+        slug_lower = slug.lower()
+        if slug != slug_lower:
+            changes.append(
+                f"  MD case:  [{text}](../{category}/{slug}) → [{text}](../{category}/{slug_lower})"
+            )
+        return f"[{text}](../{category}/{slug_lower})"
+
+    relative_md_pattern = re.compile(r"\[([^\]]+)\]\(\.\./(\w+)/([A-Za-z0-9_]+)\)")
+    new_content = relative_md_pattern.sub(fix_existing_relative_link, new_content)
+
+    # ──────────────────────────────────────────────────────────────
+    # Write changes
+    # ──────────────────────────────────────────────────────────────
+    if new_content != content:
+        if not dry_run:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(new_content)
+        return changes
+    return []
+
+
+def validate_links(docs_root: Path, valid_slugs: set[str]):
+    """Validate that all markdown link targets resolve to actual content files."""
+    # Match markdown links: [text](target)
+    link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+    issues = []
+
+    for category_dir in ["rules", "factions", "components"]:
+        dir_path = docs_root / category_dir
+        if not dir_path.exists():
+            continue
+        for filepath in sorted(dir_path.glob("*.md")):
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            for match in link_pattern.finditer(content):
+                text = match.group(1)
+                target = match.group(2)
+
+                # Skip external links
+                if target.startswith("http://") or target.startswith("https://"):
+                    continue
+
+                # Resolve the target to a slug
+                # Targets look like: ../r_foo or ../rules/r_foo
+                parts = target.strip("/").split("/")
+
+                # Determine the final slug (last path component)
+                final_slug = parts[-1].lower()
+
+                if final_slug not in valid_slugs:
+                    rel_path = filepath.relative_to(docs_root)
+                    issues.append(f"  {rel_path}: [{text}]({target}) → slug '{final_slug}' not found")
+
+    if issues:
+        print(f"\n⚠ Found {len(issues)} potentially broken link targets:\n")
+        for issue in issues:
+            print(issue)
+    else:
+        print("\n✓ All link targets resolve to valid content files.")
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    validate = "--validate" in sys.argv
+
+    valid_slugs = build_valid_slugs()
+    print(f"Found {len(valid_slugs)} valid content slugs\n")
+
+    if validate:
+        validate_links(DOCS_ROOT, valid_slugs)
+        return
+
+    if dry_run:
+        print("═══ DRY RUN MODE — no files will be modified ═══\n")
+
+    total_changes = 0
+    files_changed = 0
+
+    for category_dir in ["rules", "factions", "components"]:
+        dir_path = DOCS_ROOT / category_dir
+        if not dir_path.exists():
+            continue
+        for filepath in sorted(dir_path.glob("*.md")):
+            file_changes = fix_file(filepath, valid_slugs, dry_run)
+            if file_changes:
+                files_changed += 1
+                total_changes += len(file_changes)
+                rel = filepath.relative_to(DOCS_ROOT)
+                print(f"{rel}:")
+                for c in file_changes:
+                    print(c)
+                print()
+
+    action = "Would change" if dry_run else "Changed"
+    print(f"{'═' * 50}")
+    print(f"{action} {total_changes} links across {files_changed} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/astro-site/src/content/docs/components/C_technology.md
+++ b/astro-site/src/content/docs/components/C_technology.md
@@ -3,7 +3,7 @@ title: Technology
 ---
 
  
-For notes about specific generic unit upgrade technologies, see the <a href="C_units">unit component notes page</a>.
+For notes about specific generic unit upgrade technologies, see the [unit component notes page](../c_units).
 
  
 For notes about technologies of a specific faction, see that faction’s notes page.

--- a/astro-site/src/content/docs/components/C_units.md
+++ b/astro-site/src/content/docs/components/C_units.md
@@ -56,7 +56,7 @@ For notes about specific faction unit upgrade technology, see that faction’s n
 ## Mech
 
  
- 1. See the <a href="R_mechs">mechs page</a> of the Rules Reference.
+ 1. See the [mechs page](../rules/r_mechs) of the Rules Reference.
  2. For notes about the mechs of a specific faction, see that faction’s notes page.
  
  
@@ -70,12 +70,12 @@ For notes about specific faction unit upgrade technology, see that faction’s n
 ## PDS
 
  
- 1. See the <a href="R_pds">PDS page</a> of the Rules Reference.
+ 1. See the [PDS page](../rules/r_pds) of the Rules Reference.
  
  
 ## Space Dock
 
  
- 1. See the <a href="R_space_dock">space dock page</a> of the Rules Reference.
+ 1. See the [space dock page](../rules/r_space_dock) of the Rules Reference.
  
  

--- a/astro-site/src/content/docs/factions/F_vuilraith.md
+++ b/astro-site/src/content/docs/factions/F_vuilraith.md
@@ -8,7 +8,7 @@ title: The Vuil’raith Cabal
  
  1. When an opponent’s Infantry II is destroyed during combat, the Vuil’raith player captures an infantry token, and the opponent rolls for resurrection, placing the destroyed infantry on the Infantry II unit upgrade card if successful.
  2. The Vuil’raith player cannot capture the Ul player’s Hel Titan PDS.
- 3. For additional information, see the <a href="/rules/r_capture">Capture rules reference page</a>.
+ 3. For additional information, see the [Capture rules reference page](../rules/r_capture).
  
  
 ## Amalgamation

--- a/astro-site/src/content/docs/rules/R_abilities.md
+++ b/astro-site/src/content/docs/rules/R_abilities.md
@@ -77,7 +77,7 @@ Cards and faction sheets each have abilities that players can resolve to trigger
  
     1. Each unit on the board is its own separate physical object. For example, two or more of the N’orr player’s <i>Exotrireme II</i> in a system may use their ability to destroy themselves and other ships, as the ability is linked to the units on the game board, and not the unit upgrade technology card.
 
-3. Multiple action cards with the same name cannot be played during a single timing window to affect the same units or game effect. See the [action cards page](r_action_cards) for more details.
+3. Multiple action cards with the same name cannot be played during a single timing window to affect the same units or game effect. See the [action cards page](../r_action_cards) for more details.
 4. During the action phase, abilities are resolved in the current relative turn order, starting with the active player. For example, if it is currently the <i>Trade</i> (5) player’s turn, they will have the option to resolve first, then the <i>Warfare</i> (6) player, then the <i>Technology</i> (7) player, and so on.
  
     1. If a player has multiple abilities they wish to resolve, they must be resolved one at a time. Between each ability being resolved, each other player will have the opportunity to resolve one ability.
@@ -95,14 +95,14 @@ Cards and faction sheets each have abilities that players can resolve to trigger
 ## Related Topics
 
  
- - [Action Cards](r_action_cards)
- - [Active Player](r_active_player)
- - [Initiative Order](r_initiative_order)
- - [Leaders](r_leaders)
- - [Promissory Notes](r_promissory_notes)
- - [Relics](r_relics)
- - [Speaker](r_speaker)
- - [Strategy Card](r_strategy_card)
- - [Technology](r_technology)
+ - [Action Cards](../r_action_cards)
+ - [Active Player](../r_active_player)
+ - [Initiative Order](../r_initiative_order)
+ - [Leaders](../r_leaders)
+ - [Promissory Notes](../r_promissory_notes)
+ - [Relics](../r_relics)
+ - [Speaker](../r_speaker)
+ - [Strategy Card](../r_strategy_card)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_action_cards.md
+++ b/astro-site/src/content/docs/rules/R_action_cards.md
@@ -49,9 +49,9 @@ Action cards provide players with various abilities that they can resolve as des
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Component Action](r_component_action)
- - [Politics](r_politics)
- - [Status Phase](r_status_phase)
+ - [Abilities](../r_abilities)
+ - [Component Action](../r_component_action)
+ - [Politics](../r_politics)
+ - [Status Phase](../r_status_phase)
  
  

--- a/astro-site/src/content/docs/rules/R_action_phase.md
+++ b/astro-site/src/content/docs/rules/R_action_phase.md
@@ -36,12 +36,12 @@ During the action phase, each player takes a turn in initiative order. During a 
 ## Related Topics
 
  
- - [Active Player](r_active_player)
- - [Component Action](r_component_action)
- - [Game Round](r_game_round)
- - [Initiative Order](r_initiative_order)
- - [Status Phase](r_status_phase)
- - [Strategic Action](r_strategic_action)
- - [Tactical Action](r_tactical_action)
+ - [Active Player](../r_active_player)
+ - [Component Action](../r_component_action)
+ - [Game Round](../r_game_round)
+ - [Initiative Order](../r_initiative_order)
+ - [Status Phase](../r_status_phase)
+ - [Strategic Action](../r_strategic_action)
+ - [Tactical Action](../r_tactical_action)
  
  

--- a/astro-site/src/content/docs/rules/R_active_player.md
+++ b/astro-site/src/content/docs/rules/R_active_player.md
@@ -27,10 +27,10 @@ The active player is the player taking a turn during the action phase.
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Action Phase](r_action_phase)
- - [Attacker](r_attacker)
- - [Initiative Order](r_initiative_order)
- - [Space Cannon](r_space_cannon)
+ - [Abilities](../r_abilities)
+ - [Action Phase](../r_action_phase)
+ - [Attacker](../r_attacker)
+ - [Initiative Order](../r_initiative_order)
+ - [Space Cannon](../r_space_cannon)
  
  

--- a/astro-site/src/content/docs/rules/R_active_system.md
+++ b/astro-site/src/content/docs/rules/R_active_system.md
@@ -29,9 +29,9 @@ The active system is the system that is activated during a tactical action.
 ## Related Topics
 
  
- - [Movement](r_movement)
- - [Nebula](r_nebula)
- - [System Tiles](r_system_tiles)
- - [Tactical Action](r_tactical_action)
+ - [Movement](../r_movement)
+ - [Nebula](../r_nebula)
+ - [System Tiles](../r_system_tiles)
+ - [Tactical Action](../r_tactical_action)
  
  

--- a/astro-site/src/content/docs/rules/R_adjacency.md
+++ b/astro-site/src/content/docs/rules/R_adjacency.md
@@ -28,13 +28,13 @@ Two system tiles are adjacent to each other if any of the tiles’ sides are tou
 ## Related Topics
 
  
- - [Game Board](r_game_board)
- - [Hyperlanes](r_hyperlanes)
- - [Movement](r_movement)
- - [Neighbors](r_neighbors)
- - [PDS](r_pds)
- - [System Tiles](r_system_tiles)
- - [Wormhole Nexus](r_wormhole_nexus)
- - [Wormholes](r_wormholes)
+ - [Game Board](../r_game_board)
+ - [Hyperlanes](../r_hyperlanes)
+ - [Movement](../r_movement)
+ - [Neighbors](../r_neighbors)
+ - [PDS](../r_pds)
+ - [System Tiles](../r_system_tiles)
+ - [Wormhole Nexus](../r_wormhole_nexus)
+ - [Wormholes](../r_wormholes)
  
  

--- a/astro-site/src/content/docs/rules/R_agenda_card.md
+++ b/astro-site/src/content/docs/rules/R_agenda_card.md
@@ -30,10 +30,10 @@ Agenda cards represent galactic laws and policies. During each agenda phase, pla
 ## Related Topics
 
  
- - [Agenda Phase](r_agenda_phase)
- - [Attach](r_attach)
- - [Politics](r_politics)
- - [Speaker](r_speaker)
- - [Victory Points](r_victory_points)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Attach](../r_attach)
+ - [Politics](../r_politics)
+ - [Speaker](../r_speaker)
+ - [Victory Points](../r_victory_points)
  
  

--- a/astro-site/src/content/docs/rules/R_agenda_phase.md
+++ b/astro-site/src/content/docs/rules/R_agenda_phase.md
@@ -75,11 +75,11 @@ When voting during the agenda phase, a player can cast votes for a specific outc
 ## Related Topics
 
  
- - [Agenda Cards](r_agenda_card)
- - [Custodians Token](r_custodians_token)
- - [Game Round](r_game_round)
- - [Influence](r_influence)
- - [Speaker](r_speaker)
- - [Transactions](r_transactions)
+ - [Agenda Cards](../r_agenda_card)
+ - [Custodians Token](../r_custodians_token)
+ - [Game Round](../r_game_round)
+ - [Influence](../r_influence)
+ - [Speaker](../r_speaker)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_anomalies.md
+++ b/astro-site/src/content/docs/rules/R_anomalies.md
@@ -30,11 +30,11 @@ An anomaly is a system tile that has unique rules.
 ## Related Topics
 
  
- - [Asteroid Field](r_asteroid_field)
- - [Gravity Rift](r_gravity_rift)
- - [Movement](r_movement)
- - [Nebula](r_nebula)
- - [Supernova](r_supernova)
- - [System Tiles](r_system_tiles)
+ - [Asteroid Field](../r_asteroid_field)
+ - [Gravity Rift](../r_gravity_rift)
+ - [Movement](../r_movement)
+ - [Nebula](../r_nebula)
+ - [Supernova](../r_supernova)
+ - [System Tiles](../r_system_tiles)
  
  

--- a/astro-site/src/content/docs/rules/R_anti_fighter_barrage.md
+++ b/astro-site/src/content/docs/rules/R_anti_fighter_barrage.md
@@ -33,8 +33,8 @@ A unit with the Anti–Fighter Barrage ability may be able to destroy an opponen
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Destroyed](r_destroyed)
- - [Space Combat](r_space_combat)
+ - [Abilities](../r_abilities)
+ - [Destroyed](../r_destroyed)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_asteroid_field.md
+++ b/astro-site/src/content/docs/rules/R_asteroid_field.md
@@ -22,7 +22,7 @@ An asteroid field is an anomaly that affects movement.
 ## Related Topics
 
  
- - [Anomalies](r_anomalies)
- - [Movement](r_movement)
+ - [Anomalies](../r_anomalies)
+ - [Movement](../r_movement)
  
  

--- a/astro-site/src/content/docs/rules/R_attach.md
+++ b/astro-site/src/content/docs/rules/R_attach.md
@@ -28,9 +28,9 @@ Some game effects instruct a player to attach a card to a planet card. The attac
 ## Related Topics
 
  
- - [Agenda Card](r_agenda_card)
- - [Control](r_control)
- - [Exploration](r_exploration)
- - [Planets](r_planets)
+ - [Agenda Card](../r_agenda_card)
+ - [Control](../r_control)
+ - [Exploration](../r_exploration)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_attacker.md
+++ b/astro-site/src/content/docs/rules/R_attacker.md
@@ -25,12 +25,12 @@ During combat, the active player is the attacker.
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Active Player](r_active_player)
- - [Defender](r_defender)
- - [Ground Combat](r_ground_combat)
- - [Invasion](r_invasion)
- - [Opponent](r_opponent)
- - [Space Combat](r_space_combat)
+ - [Abilities](../r_abilities)
+ - [Active Player](../r_active_player)
+ - [Defender](../r_defender)
+ - [Ground Combat](../r_ground_combat)
+ - [Invasion](../r_invasion)
+ - [Opponent](../r_opponent)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_blockaded.md
+++ b/astro-site/src/content/docs/rules/R_blockaded.md
@@ -30,10 +30,10 @@ A player’s unit with Production is blockaded if it is in a system that does no
 ## Related Topics
 
  
- - [Capture](r_capture)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Ships](r_ships)
- - [Space Dock](r_space_dock)
+ - [Capture](../r_capture)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Ships](../r_ships)
+ - [Space Dock](../r_space_dock)
  
  

--- a/astro-site/src/content/docs/rules/R_bombardment.md
+++ b/astro-site/src/content/docs/rules/R_bombardment.md
@@ -48,10 +48,10 @@ A unit with the Bombardment ability may be able to destroy another player’s gr
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Destroyed](r_destroyed)
- - [Ground Forces](r_ground_forces)
- - [Invasion](r_invasion)
- - [Planetary Shield](r_planetary_shield)
+ - [Abilities](../r_abilities)
+ - [Destroyed](../r_destroyed)
+ - [Ground Forces](../r_ground_forces)
+ - [Invasion](../r_invasion)
+ - [Planetary Shield](../r_planetary_shield)
  
  

--- a/astro-site/src/content/docs/rules/R_breakthroughs.md
+++ b/astro-site/src/content/docs/rules/R_breakthroughs.md
@@ -27,8 +27,8 @@ There currently does not exist a Living Rules Reference section regarding breakt
 ## Related Topics
 
  
- - [Expedition](r_expedition)
- - [The Fracture](r_fracture)
- - [Synergy](r_synergy)
+ - [Expedition](../r_expedition)
+ - [The Fracture](../r_fracture)
+ - [Synergy](../r_synergy)
  
  

--- a/astro-site/src/content/docs/rules/R_capacity.md
+++ b/astro-site/src/content/docs/rules/R_capacity.md
@@ -40,9 +40,9 @@ Capacity is an attribute of some units that is presented on faction sheets and u
 ## Related Topics
 
  
- - [Fleet Pool](r_fleet_pool)
- - [Movement](r_movement)
- - [Space Combat](r_space_combat)
- - [Transport](r_transport)
+ - [Fleet Pool](../r_fleet_pool)
+ - [Movement](../r_movement)
+ - [Space Combat](../r_space_combat)
+ - [Transport](../r_transport)
  
  

--- a/astro-site/src/content/docs/rules/R_capture.md
+++ b/astro-site/src/content/docs/rules/R_capture.md
@@ -46,9 +46,9 @@ Some abilities instruct a player to capture a unit, preventing the unit’s orig
 ## Related Topics
 
  
- - [Blockaded](r_blockaded)
- - [Fighter Tokens](r_fighter_tokens)
- - [Infantry Tokens](r_infantry_tokens)
- - [Transactions](r_transactions)
+ - [Blockaded](../r_blockaded)
+ - [Fighter Tokens](../r_fighter_tokens)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_coexistence.md
+++ b/astro-site/src/content/docs/rules/R_coexistence.md
@@ -36,7 +36,7 @@ There currently does not exist a Living Rules Reference section regarding coexis
 ## Related Topics
 
  
- - [Control](r_control)
- - [Planets](r_planets)
+ - [Control](../r_control)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_combat.md
+++ b/astro-site/src/content/docs/rules/R_combat.md
@@ -22,9 +22,9 @@ Combat is an attribute of some units that is presented on faction sheets and uni
 ## Related Topics
 
  
- - [Ground Combat](r_ground_combat)
- - [Modifiers](r_modifiers)
- - [Space Combat](r_space_combat)
- - [Units](r_units)
+ - [Ground Combat](../r_ground_combat)
+ - [Modifiers](../r_modifiers)
+ - [Space Combat](../r_space_combat)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_command_sheet.md
+++ b/astro-site/src/content/docs/rules/R_command_sheet.md
@@ -23,10 +23,10 @@ Each player has a command sheet that contains a strategy pool, a tactic pool, a 
 ## Related Topics
 
  
- - [Command Tokens](r_command_tokens)
- - [Fleet Pool](r_fleet_pool)
- - [Strategic Action](r_strategic_action)
- - [Tactical Action](r_tactical_action)
- - [Trade Goods](r_trade_goods)
+ - [Command Tokens](../r_command_tokens)
+ - [Fleet Pool](../r_fleet_pool)
+ - [Strategic Action](../r_strategic_action)
+ - [Tactical Action](../r_tactical_action)
+ - [Trade Goods](../r_trade_goods)
  
  

--- a/astro-site/src/content/docs/rules/R_command_tokens.md
+++ b/astro-site/src/content/docs/rules/R_command_tokens.md
@@ -36,11 +36,11 @@ Command tokens are a currency that players use to perform actions and expand the
 ## Related Topics
 
  
- - [Command Sheet](r_command_sheet)
- - [Fleet Pool](r_fleet_pool)
- - [Leadership](r_leadership)
- - [Reinforcements](r_reinforcements)
- - [Strategic Action](r_strategic_action)
- - [Tactical Action](r_tactical_action)
+ - [Command Sheet](../r_command_sheet)
+ - [Fleet Pool](../r_fleet_pool)
+ - [Leadership](../r_leadership)
+ - [Reinforcements](../r_reinforcements)
+ - [Strategic Action](../r_strategic_action)
+ - [Tactical Action](../r_tactical_action)
  
  

--- a/astro-site/src/content/docs/rules/R_commodities.md
+++ b/astro-site/src/content/docs/rules/R_commodities.md
@@ -34,9 +34,9 @@ Commodities represent goods that are plentiful for their own faction and are des
 ## Related Topics
 
  
- - [Deals](r_deals)
- - [Trade](r_trade)
- - [Trade Goods](r_trade_goods)
- - [Transactions](r_transactions)
+ - [Deals](../r_deals)
+ - [Trade](../r_trade)
+ - [Trade Goods](../r_trade_goods)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_component_action.md
+++ b/astro-site/src/content/docs/rules/R_component_action.md
@@ -24,13 +24,13 @@ A component action is a type of action that a player can perform during their tu
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Action Cards](r_action_cards)
- - [Action Phase](r_action_phase)
- - [Exploration](r_exploration)
- - [Leaders](r_leaders)
- - [Promissory Notes](r_promissory_notes)
- - [Relics](r_relics)
- - [Technology](r_technology)
+ - [Abilities](../r_abilities)
+ - [Action Cards](../r_action_cards)
+ - [Action Phase](../r_action_phase)
+ - [Exploration](../r_exploration)
+ - [Leaders](../r_leaders)
+ - [Promissory Notes](../r_promissory_notes)
+ - [Relics](../r_relics)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_component_limitations.md
+++ b/astro-site/src/content/docs/rules/R_component_limitations.md
@@ -42,9 +42,9 @@ If a component type is depleted during the game, players obey the following rule
 ## Related Topics
 
  
- - [Fighter Tokens](r_fighter_tokens)
- - [Infantry Tokens](r_infantry_tokens)
- - [Producing Units](r_producing_units)
- - [Units](r_units)
+ - [Fighter Tokens](../r_fighter_tokens)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Producing Units](../r_producing_units)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_construction.md
+++ b/astro-site/src/content/docs/rules/R_construction.md
@@ -33,11 +33,11 @@ The <i>Construction</i> strategy card allows players to construct structures on 
 ## Related Topics
 
  
- - [Initiative Order](r_initiative_order)
- - [PDS](r_pds)
- - [Space Dock](r_space_dock)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
- - [Structures](r_structures)
+ - [Initiative Order](../r_initiative_order)
+ - [PDS](../r_pds)
+ - [Space Dock](../r_space_dock)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
+ - [Structures](../r_structures)
  
  

--- a/astro-site/src/content/docs/rules/R_control.md
+++ b/astro-site/src/content/docs/rules/R_control.md
@@ -36,9 +36,9 @@ Each player begins the game with control of each planet in their home system. Du
 ## Related Topics
 
  
- - [Attach](r_attach)
- - [Exhausted](r_exhausted)
- - [Invasion](r_invasion)
- - [Planets](r_planets)
+ - [Attach](../r_attach)
+ - [Exhausted](../r_exhausted)
+ - [Invasion](../r_invasion)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_cost.md
+++ b/astro-site/src/content/docs/rules/R_cost.md
@@ -27,8 +27,8 @@ Cost is an attribute of some units that is presented on faction sheets and unit 
 ## Related Topics
 
  
- - [Modifiers](r_modifiers)
- - [Producing Units](r_producing_units)
- - [Resources](r_resources)
+ - [Modifiers](../r_modifiers)
+ - [Producing Units](../r_producing_units)
+ - [Resources](../r_resources)
  
  

--- a/astro-site/src/content/docs/rules/R_custodians_token.md
+++ b/astro-site/src/content/docs/rules/R_custodians_token.md
@@ -27,11 +27,11 @@ The custodians token begins each game on Mecatol Rex. The token represents the c
 ## Related Topics
 
  
- - [Agenda Phase](r_agenda_phase)
- - [Control](r_control)
- - [Influence](r_influence)
- - [Invasion](r_invasion)
- - [Mecatol Rex](r_mecatol_rex)
- - [Victory Points](r_victory_points)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Control](../r_control)
+ - [Influence](../r_influence)
+ - [Invasion](../r_invasion)
+ - [Mecatol Rex](../r_mecatol_rex)
+ - [Victory Points](../r_victory_points)
  
  

--- a/astro-site/src/content/docs/rules/R_deals.md
+++ b/astro-site/src/content/docs/rules/R_deals.md
@@ -39,8 +39,8 @@ A deal is an agreement between two players that may or may not include a transac
 ## Related Topics
 
  
- - [Promissory Notes](r_promissory_notes)
- - [Trade Goods](r_trade_goods)
- - [Transactions](r_transactions)
+ - [Promissory Notes](../r_promissory_notes)
+ - [Trade Goods](../r_trade_goods)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_defender.md
+++ b/astro-site/src/content/docs/rules/R_defender.md
@@ -23,11 +23,11 @@ During either a space or ground combat, the player who is not the active player 
 ## Related Topics
 
  
- - [Attacker](r_attacker)
- - [Ground Combat](r_ground_combat)
- - [Invasion](r_invasion)
- - [Nebula](r_nebula)
- - [Opponent](r_opponent)
- - [Space Combat](r_space_combat)
+ - [Attacker](../r_attacker)
+ - [Ground Combat](../r_ground_combat)
+ - [Invasion](../r_invasion)
+ - [Nebula](../r_nebula)
+ - [Opponent](../r_opponent)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_deploy.md
+++ b/astro-site/src/content/docs/rules/R_deploy.md
@@ -28,8 +28,8 @@ Some units have deploy abilities. Deploy abilities are indicated by the Deploy h
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Mechs](r_mechs)
- - [Reinforcements](r_reinforcements)
+ - [Abilities](../r_abilities)
+ - [Mechs](../r_mechs)
+ - [Reinforcements](../r_reinforcements)
  
  

--- a/astro-site/src/content/docs/rules/R_destroyed.md
+++ b/astro-site/src/content/docs/rules/R_destroyed.md
@@ -21,11 +21,11 @@ Various game effects can cause a unit to be destroyed. When a player’s unit is
 ## Related Topics
 
  
- - [Anti–Fighter Barrage](r_anti_fighter_barrage)
- - [Bombardment](r_bombardment)
- - [Ground Combat](r_ground_combat)
- - [Space Cannon](r_space_cannon)
- - [Space Combat](r_space_combat)
- - [Sustain Damage](r_sustain_damage)
+ - [Anti–Fighter Barrage](../r_anti_fighter_barrage)
+ - [Bombardment](../r_bombardment)
+ - [Ground Combat](../r_ground_combat)
+ - [Space Cannon](../r_space_cannon)
+ - [Space Combat](../r_space_combat)
+ - [Sustain Damage](../r_sustain_damage)
  
  

--- a/astro-site/src/content/docs/rules/R_diplomacy.md
+++ b/astro-site/src/content/docs/rules/R_diplomacy.md
@@ -35,12 +35,12 @@ The <i>Diplomacy</i> strategy card can be used to preemptively prevent other pla
 ## Related Topics
 
  
- - [Active System](r_active_system)
- - [Command Tokens](r_command_tokens)
- - [Initiative Order](r_initiative_order)
- - [Planets](r_planets)
- - [Readied](r_readied)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
+ - [Active System](../r_active_system)
+ - [Command Tokens](../r_command_tokens)
+ - [Initiative Order](../r_initiative_order)
+ - [Planets](../r_planets)
+ - [Readied](../r_readied)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
  
  

--- a/astro-site/src/content/docs/rules/R_elimination.md
+++ b/astro-site/src/content/docs/rules/R_elimination.md
@@ -53,8 +53,8 @@ A player who is eliminated is no longer part of the game.
 ## Related Topics
 
  
- - [Control](r_control)
- - [Ground Forces](r_ground_forces)
- - [Production](r_production)
+ - [Control](../r_control)
+ - [Ground Forces](../r_ground_forces)
+ - [Production](../r_production)
  
  

--- a/astro-site/src/content/docs/rules/R_entropic_scars.md
+++ b/astro-site/src/content/docs/rules/R_entropic_scars.md
@@ -32,8 +32,8 @@ There currently does not exist a Living Rules Reference section regarding entrop
 ## Related Topics
 
  
- - [Anomalies](r_anomalies)
- - [Abilities](r_abilities)
- - [Technology](r_techonolgy)
+ - [Anomalies](../r_anomalies)
+ - [Abilities](../r_abilities)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_exhausted.md
+++ b/astro-site/src/content/docs/rules/R_exhausted.md
@@ -29,13 +29,13 @@ Some cards can be exhausted. A player cannot resolve abilities or spend the reso
 ## Related Topics
 
  
- - [Influence](r_influence)
- - [Leaders](r_leaders)
- - [Planets](r_planets)
- - [Relics](r_relics)
- - [Resources](r_resources)
- - [Strategy Card](r_strategy_card)
- - [Status Phase](r_status_phase)
- - [Technology](r_technology)
+ - [Influence](../r_influence)
+ - [Leaders](../r_leaders)
+ - [Planets](../r_planets)
+ - [Relics](../r_relics)
+ - [Resources](../r_resources)
+ - [Strategy Card](../r_strategy_card)
+ - [Status Phase](../r_status_phase)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_expedition.md
+++ b/astro-site/src/content/docs/rules/R_expedition.md
@@ -41,7 +41,7 @@ There currently does not exist a Living Rules Reference section regarding expedi
 ## Related Topics
 
  
- - [Breakthroughs](r_breakthroughs)
- - [The Fracture](r_fracture)
+ - [Breakthroughs](../r_breakthroughs)
+ - [The Fracture](../r_fracture)
  
  

--- a/astro-site/src/content/docs/rules/R_exploration.md
+++ b/astro-site/src/content/docs/rules/R_exploration.md
@@ -50,13 +50,13 @@ Planets and some space areas can be explored, yielding varying results determine
 ## Related Topics
 
  
- - [Attach](r_attach)
- - [Control](r_control)
- - [Frontier Tokens](r_frontier_tokens)
- - [Invasion](r_invasion)
- - [Planets](r_planets)
- - [Purge](R_purge)
- - [Relics](r_relics)
- - [Transactions](r_transactions)
+ - [Attach](../r_attach)
+ - [Control](../r_control)
+ - [Frontier Tokens](../r_frontier_tokens)
+ - [Invasion](../r_invasion)
+ - [Planets](../r_planets)
+ - [Purge](../r_purge)
+ - [Relics](../r_relics)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_fighter_tokens.md
+++ b/astro-site/src/content/docs/rules/R_fighter_tokens.md
@@ -30,8 +30,8 @@ A fighter token functions as a plastic fighter unit for all game purposes.
 ## Related Topics
 
  
- - [Component Limitations](r_component_limitations)
- - [Infantry Tokens](r_infantry_tokens)
- - [Producing Units](r_producing_units)
+ - [Component Limitations](../r_component_limitations)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Producing Units](../r_producing_units)
  
  

--- a/astro-site/src/content/docs/rules/R_fleet_pool.md
+++ b/astro-site/src/content/docs/rules/R_fleet_pool.md
@@ -33,10 +33,10 @@ The fleet pool is an area of a player’s command sheet.
 ## Related Topics
 
  
- - [Capacity](r_capacity)
- - [Command Sheet](r_command_sheet)
- - [Command Tokens](r_command_tokens)
- - [Ships](r_ships)
- - [System Tiles](r_system_tiles)
+ - [Capacity](../r_capacity)
+ - [Command Sheet](../r_command_sheet)
+ - [Command Tokens](../r_command_tokens)
+ - [Ships](../r_ships)
+ - [System Tiles](../r_system_tiles)
  
  

--- a/astro-site/src/content/docs/rules/R_fracture.md
+++ b/astro-site/src/content/docs/rules/R_fracture.md
@@ -41,9 +41,9 @@ There currently does not exist a Living Rules Reference section regarding The Fr
 ## Related Topics
 
  
- - [Breakthroughs](r_breakthroughs)
- - [Neutral Units](r_neutral_units)
- - [Relics](r_relics)
- - [Synergy](r_synergy)
+ - [Breakthroughs](../r_breakthroughs)
+ - [Neutral Units](../r_neutral_units)
+ - [Relics](../r_relics)
+ - [Synergy](../r_synergy)
  
  

--- a/astro-site/src/content/docs/rules/R_frontier_tokens.md
+++ b/astro-site/src/content/docs/rules/R_frontier_tokens.md
@@ -27,6 +27,6 @@ Frontier tokens can be explored for a variety of game effects.
 ## Related Topics
 
  
- - [Exploration](r_exploration)
+ - [Exploration](../r_exploration)
  
  

--- a/astro-site/src/content/docs/rules/R_game_board.md
+++ b/astro-site/src/content/docs/rules/R_game_board.md
@@ -29,8 +29,8 @@ The game board consists of all system tiles in play.
 ## Related Topics
 
  
- - [Adjacency](r_adjacency)
- - [Hyperlanes](r_hyperlanes)
- - [System Tiles](r_system_tiles)
+ - [Adjacency](../r_adjacency)
+ - [Hyperlanes](../r_hyperlanes)
+ - [System Tiles](../r_system_tiles)
  
  

--- a/astro-site/src/content/docs/rules/R_game_round.md
+++ b/astro-site/src/content/docs/rules/R_game_round.md
@@ -30,10 +30,10 @@ A game round consists of the following four phases:
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Agenda Phase](r_agenda_phase)
- - [Custodians Token](r_custodians_token)
- - [Status Phase](r_status_phase)
- - [Strategy Phase](r_strategy_phase)
+ - [Action Phase](../r_action_phase)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Custodians Token](../r_custodians_token)
+ - [Status Phase](../r_status_phase)
+ - [Strategy Phase](../r_strategy_phase)
  
  

--- a/astro-site/src/content/docs/rules/R_gravity_rift.md
+++ b/astro-site/src/content/docs/rules/R_gravity_rift.md
@@ -46,8 +46,8 @@ A gravity rift is an anomaly that affects movement.
 ## Related Topics
 
  
- - [Anomalies](r_anomalies)
- - [Movement](r_movement)
- - [Transport](r_transport)
+ - [Anomalies](../r_anomalies)
+ - [Movement](../r_movement)
+ - [Transport](../r_transport)
  
  

--- a/astro-site/src/content/docs/rules/R_ground_combat.md
+++ b/astro-site/src/content/docs/rules/R_ground_combat.md
@@ -42,16 +42,16 @@ During the <b>Ground Combat</b> step of an invasion, if the active player has gr
 ## Related Topics
 
  
- - [Attacker](r_attacker)
- - [Combat](r_combat)
- - [Defender](r_defender)
- - [Destroyed](r_destroyed)
- - [Ground Forces](r_ground_forces)
- - [Invasion](r_invasion)
- - [Modifiers](r_modifiers)
- - [Opponent](r_opponent)
- - [Planets](r_planets)
- - [Rerolls](r_rerolls)
- - [Sustain Damage](r_sustain_damage)
+ - [Attacker](../r_attacker)
+ - [Combat](../r_combat)
+ - [Defender](../r_defender)
+ - [Destroyed](../r_destroyed)
+ - [Ground Forces](../r_ground_forces)
+ - [Invasion](../r_invasion)
+ - [Modifiers](../r_modifiers)
+ - [Opponent](../r_opponent)
+ - [Planets](../r_planets)
+ - [Rerolls](../r_rerolls)
+ - [Sustain Damage](../r_sustain_damage)
  
  

--- a/astro-site/src/content/docs/rules/R_ground_forces.md
+++ b/astro-site/src/content/docs/rules/R_ground_forces.md
@@ -22,12 +22,12 @@ A ground force is a type of unit. All infantry and mech units in the game are gr
 ## Related Topics
 
  
- - [Capacity](r_capacity)
- - [Control](r_control)
- - [Ground Combat](r_ground_combat)
- - [Infantry Tokens](r_infantry_tokens)
- - [Mechs](r_mechs)
- - [Transport](r_transport)
- - [Units](r_units)
+ - [Capacity](../r_capacity)
+ - [Control](../r_control)
+ - [Ground Combat](../r_ground_combat)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Mechs](../r_mechs)
+ - [Transport](../r_transport)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_hyperlanes.md
+++ b/astro-site/src/content/docs/rules/R_hyperlanes.md
@@ -34,11 +34,11 @@ Hyperlanes are tiles that are used in some game board setups to create adjacency
 ## Related Topics
 
  
- - [Adjacency](r_adjacency)
- - [Game Board](r_game_board)
- - [Movement](r_movement)
- - [Neighbors](r_neighbors)
- - [Space Cannon](r_space_cannon)
- - [System Tiles](r_system_tiles)
+ - [Adjacency](../r_adjacency)
+ - [Game Board](../r_game_board)
+ - [Movement](../r_movement)
+ - [Neighbors](../r_neighbors)
+ - [Space Cannon](../r_space_cannon)
+ - [System Tiles](../r_system_tiles)
  
  

--- a/astro-site/src/content/docs/rules/R_imperial.md
+++ b/astro-site/src/content/docs/rules/R_imperial.md
@@ -27,11 +27,11 @@ The <i>Imperial</i> strategy card allows players to score victory points and dra
 ## Related Topics
 
  
- - [Initiative Order](r_initiative_order)
- - [Mecatol Rex](r_mecatol_rex)
- - [Objective Cards](r_objective_cards)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
- - [Victory Points](r_victory_points)
+ - [Initiative Order](../r_initiative_order)
+ - [Mecatol Rex](../r_mecatol_rex)
+ - [Objective Cards](../r_objective_cards)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
+ - [Victory Points](../r_victory_points)
  
  

--- a/astro-site/src/content/docs/rules/R_infantry_tokens.md
+++ b/astro-site/src/content/docs/rules/R_infantry_tokens.md
@@ -31,8 +31,8 @@ An infantry token functions as a plastic infantry unit for all game purposes.
 ## Related Topics
 
  
- - [Component Limitations](r_component_limitations)
- - [Fighter Tokens](r_fighter_tokens)
- - [Producing Units](r_producing_units)
+ - [Component Limitations](../r_component_limitations)
+ - [Fighter Tokens](../r_fighter_tokens)
+ - [Producing Units](../r_producing_units)
  
  

--- a/astro-site/src/content/docs/rules/R_influence.md
+++ b/astro-site/src/content/docs/rules/R_influence.md
@@ -25,10 +25,10 @@ Influence represents a planet’s political power. Players spend influence to ga
 ## Related Topics
 
  
- - [Agenda Phase](r_agenda_phase)
- - [Custodians Token](r_custodians_token)
- - [Exhausted](r_exhausted)
- - [Leadership](r_leadership)
- - [Planets](r_planets)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Custodians Token](../r_custodians_token)
+ - [Exhausted](../r_exhausted)
+ - [Leadership](../r_leadership)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_initiative_order.md
+++ b/astro-site/src/content/docs/rules/R_initiative_order.md
@@ -23,27 +23,27 @@ Initiative order is the order in which players resolve steps of the action and s
 ## Notes
 
  
-1. If there are multiple abilities that players wish to resolve at the same time during the action phase, initiative order will determine the order they are resolved in. See the [abilities page](r_abilities) for more details.
+1. If there are multiple abilities that players wish to resolve at the same time during the action phase, initiative order will determine the order they are resolved in. See the [abilities page](../r_abilities) for more details.
 2. The initiative order of all strategy cards is:
  
-    1. [Leadership](r_leadership)
-    2. [Diplomacy](r_diplomacy)
-    3. [Politics](r_politics)
-    4. [Construction](r_construction)
-    5. [Trade](r_trade)
-    6. [Warfare](r_warfare)
-    7. <a href="/rules/r_technology_sc">Technology (<abbr title="Strategy Card">S.C.</abbr>)</sub></a>
-    8. [Imperial](r_imperial)
+    1. [Leadership](../r_leadership)
+    2. [Diplomacy](../r_diplomacy)
+    3. [Politics](../r_politics)
+    4. [Construction](../r_construction)
+    5. [Trade](../r_trade)
+    6. [Warfare](../r_warfare)
+    7. [Technology (<abbr title="Strategy Card">S.C.</abbr>)](../r_technology_sc)
+    8. [Imperial](../r_imperial)
  
  
  
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Action Phase](r_action_phase)
- - [Active Player](r_active_player)
- - [Strategy Card](r_strategy_card)
- - [Status Phase](r_status_phase)
+ - [Abilities](../r_abilities)
+ - [Action Phase](../r_action_phase)
+ - [Active Player](../r_active_player)
+ - [Strategy Card](../r_strategy_card)
+ - [Status Phase](../r_status_phase)
  
  

--- a/astro-site/src/content/docs/rules/R_invasion.md
+++ b/astro-site/src/content/docs/rules/R_invasion.md
@@ -48,15 +48,15 @@ To resolve an invasion, players perform the following steps:
 ## Related Topics
 
  
- - [Active Player](r_active_player)
- - [Bombardment](r_bombardment)
- - [Combat](r_combat)
- - [Control](r_control)
- - [Custodians Token](r_custodians_token)
- - [Exploration](r_exploration)
- - [Ground Combat](r_ground_combat)
- - [Ground Forces](r_ground_forces)
- - [Planets](r_planets)
- - [Space Cannon](r_space_cannon)
+ - [Active Player](../r_active_player)
+ - [Bombardment](../r_bombardment)
+ - [Combat](../r_combat)
+ - [Control](../r_control)
+ - [Custodians Token](../r_custodians_token)
+ - [Exploration](../r_exploration)
+ - [Ground Combat](../r_ground_combat)
+ - [Ground Forces](../r_ground_forces)
+ - [Planets](../r_planets)
+ - [Space Cannon](../r_space_cannon)
  
  

--- a/astro-site/src/content/docs/rules/R_leader_sheet.md
+++ b/astro-site/src/content/docs/rules/R_leader_sheet.md
@@ -25,7 +25,7 @@ Each player has a leader sheet that contains slots for their faction’s three l
 ## Related Topics
 
  
- - [Leaders](r_leaders)
- - [Mechs](r_mechs)
+ - [Leaders](../r_leaders)
+ - [Mechs](../r_mechs)
  
  

--- a/astro-site/src/content/docs/rules/R_leaders.md
+++ b/astro-site/src/content/docs/rules/R_leaders.md
@@ -62,11 +62,11 @@ Each player has several faction–specific leader cards that represent character
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Component Action](r_component_action)
- - [Exhausted](r_exhausted)
- - [Leader Sheet](r_leader_sheet)
- - [Purge](r_purge)
- - [Readied](r_readied)
+ - [Abilities](../r_abilities)
+ - [Component Action](../r_component_action)
+ - [Exhausted](../r_exhausted)
+ - [Leader Sheet](../r_leader_sheet)
+ - [Purge](../r_purge)
+ - [Readied](../r_readied)
  
  

--- a/astro-site/src/content/docs/rules/R_leadership.md
+++ b/astro-site/src/content/docs/rules/R_leadership.md
@@ -25,11 +25,11 @@ The <i>Leadership</i> strategy card allows players to gain command tokens. This 
 ## Related Topics
 
  
- - [Command Sheet](r_command_sheet)
- - [Command Tokens](r_command_tokens)
- - [Influence](r_influence)
- - [Initiative Order](r_initiative_order)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
+ - [Command Sheet](../r_command_sheet)
+ - [Command Tokens](../r_command_tokens)
+ - [Influence](../r_influence)
+ - [Initiative Order](../r_initiative_order)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
  
  

--- a/astro-site/src/content/docs/rules/R_legendary_planets.md
+++ b/astro-site/src/content/docs/rules/R_legendary_planets.md
@@ -29,14 +29,14 @@ Legendary planets grant the player that controls them unique, planet–specific 
 5. An ability that readies a plannet cannot be used to ready a legendary planet ability card.
 6. A legendary planet ability card will ready in the status phase.
 7. Mecatol Rex is not a legendary planet.
-8. For the system that contains Malice, see the [wormhole nexus](r_wormhole_nexus).
+8. For the system that contains Malice, see the [wormhole nexus](../r_wormhole_nexus).
  
  
 ## Related Topics
 
  
- - [Control](r_control)
- - [Exhausted](r_exhausted)
- - [Planets](r_planets)
+ - [Control](../r_control)
+ - [Exhausted](../r_exhausted)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_mecatol_rex.md
+++ b/astro-site/src/content/docs/rules/R_mecatol_rex.md
@@ -21,8 +21,8 @@ Mecatol Rex is the planet placed in the center of the game board during setup.
 ## Related Topics
 
  
- - [Custodians Token](r_custodians_token)
- - [Imperial](r_imperial)
- - [Planets](r_planets)
+ - [Custodians Token](../r_custodians_token)
+ - [Imperial](../r_imperial)
+ - [Planets](../r_planets)
  
  

--- a/astro-site/src/content/docs/rules/R_mechs.md
+++ b/astro-site/src/content/docs/rules/R_mechs.md
@@ -25,9 +25,9 @@ Mechs are unique, faction–specific heavy ground forces.
 ## Related Topics
 
  
- - [Deploy](r_deploy)
- - [Ground Forces](r_ground_forces)
- - [Leader Sheet](r_leader_sheet)
- - [Units](r_units)
+ - [Deploy](../r_deploy)
+ - [Ground Forces](../r_ground_forces)
+ - [Leader Sheet](../r_leader_sheet)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_modifiers.md
+++ b/astro-site/src/content/docs/rules/R_modifiers.md
@@ -23,12 +23,12 @@ A modifier is a number that is applied by an ability to increase or decrease the
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Anti–Fighter Barrage](r_anti_fighter_barrage)
- - [Bombardment](r_bombardment)
- - [Combat](r_combat)
- - [Cost](r_cost)
- - [Move](r_move)
- - [Space Cannon](r_space_cannon)
+ - [Abilities](../r_abilities)
+ - [Anti–Fighter Barrage](../r_anti_fighter_barrage)
+ - [Bombardment](../r_bombardment)
+ - [Combat](../r_combat)
+ - [Cost](../r_cost)
+ - [Move](../r_move)
+ - [Space Cannon](../r_space_cannon)
  
  

--- a/astro-site/src/content/docs/rules/R_move.md
+++ b/astro-site/src/content/docs/rules/R_move.md
@@ -21,10 +21,10 @@ Move is an attribute of some units that is presented on faction sheets and unit 
 ## Related Topics
 
  
- - [Modifiers](r_modifiers)
- - [Movement](r_movement)
- - [Ships](r_ships)
- - [Tactical Action](r_tactical_action)
- - [Units](r_units)
+ - [Modifiers](../r_modifiers)
+ - [Movement](../r_movement)
+ - [Ships](../r_ships)
+ - [Tactical Action](../r_tactical_action)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_movement.md
+++ b/astro-site/src/content/docs/rules/R_movement.md
@@ -48,16 +48,16 @@ To resolve movement, players perform the following steps:
 ## Related Topics
 
  
- - [Active System](r_active_system)
- - [Adjacency](r_adjacency)
- - [Anomalies](r_anomalies)
- - [Capacity](r_capacity)
- - [Hyperlanes](r_hyperlanes)
- - [Move](r_move)
- - [Ships](r_ships)
- - [Space Cannon](r_space_cannon)
- - [Tactical Action](r_tactical_action)
- - [Transport](r_transport)
- - [Wormholes](r_wormholes)
+ - [Active System](../r_active_system)
+ - [Adjacency](../r_adjacency)
+ - [Anomalies](../r_anomalies)
+ - [Capacity](../r_capacity)
+ - [Hyperlanes](../r_hyperlanes)
+ - [Move](../r_move)
+ - [Ships](../r_ships)
+ - [Space Cannon](../r_space_cannon)
+ - [Tactical Action](../r_tactical_action)
+ - [Transport](../r_transport)
+ - [Wormholes](../r_wormholes)
  
  

--- a/astro-site/src/content/docs/rules/R_nebula.md
+++ b/astro-site/src/content/docs/rules/R_nebula.md
@@ -33,10 +33,10 @@ A nebula is an anomaly that affects movement and combat.
 ## Related Topics
 
  
- - [Active System](r_active_system)
- - [Anomalies](r_anomalies)
- - [Combat](r_combat)
- - [Defender](r_defender)
- - [Move](r_move)
+ - [Active System](../r_active_system)
+ - [Anomalies](../r_anomalies)
+ - [Combat](../r_combat)
+ - [Defender](../r_defender)
+ - [Move](../r_move)
  
  

--- a/astro-site/src/content/docs/rules/R_neighbors.md
+++ b/astro-site/src/content/docs/rules/R_neighbors.md
@@ -24,7 +24,7 @@ Two players are neighbors if they both have a unit or control a planet in the sa
 ## Related Topics
 
  
- - [Adjacency](r_adjacency)
- - [Transactions](r_transactions)
+ - [Adjacency](../r_adjacency)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_neutral_units.md
+++ b/astro-site/src/content/docs/rules/R_neutral_units.md
@@ -28,8 +28,8 @@ There currently does not exist a Living Rules Reference section regarding neutra
 ## Related Topics
 
  
- - [The Fracture](r_fracture)
- - [Ground Combat](r_ground_combat)
- - [Space Combat](r_space_combat)
+ - [The Fracture](../r_fracture)
+ - [Ground Combat](../r_ground_combat)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_objective_cards.md
+++ b/astro-site/src/content/docs/rules/R_objective_cards.md
@@ -87,10 +87,10 @@ A secret objective is an objective that is controlled by one player and is hidde
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Agenda Phase](r_agenda_phase)
- - [Imperial](r_imperial)
- - [Status Phase](r_status_phase)
- - [Victory Points](r_victory_points)
+ - [Action Phase](../r_action_phase)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Imperial](../r_imperial)
+ - [Status Phase](../r_status_phase)
+ - [Victory Points](../r_victory_points)
  
  

--- a/astro-site/src/content/docs/rules/R_opponent.md
+++ b/astro-site/src/content/docs/rules/R_opponent.md
@@ -20,9 +20,9 @@ During combat, a player’s opponent is the other player that either has ships i
 ## Related Topics
 
  
- - [Attacker](r_attacker)
- - [Defender](r_defender)
- - [Ground Combat](r_ground_combat)
- - [Space Combat](r_space_combat)
+ - [Attacker](../r_attacker)
+ - [Defender](../r_defender)
+ - [Ground Combat](../r_ground_combat)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_pds.md
+++ b/astro-site/src/content/docs/rules/R_pds.md
@@ -25,10 +25,10 @@ A PDS (planetary defense system) is a structure that allows a player to defend t
 ## Related Topics
 
  
- - [Construction](r_construction)
- - [Planetary Shield](r_planetary_shield)
- - [Structures](r_structures)
- - [Space Cannon](r_space_cannon)
- - [Units](r_units)
+ - [Construction](../r_construction)
+ - [Planetary Shield](../r_planetary_shield)
+ - [Structures](../r_structures)
+ - [Space Cannon](../r_space_cannon)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_planetary_shield.md
+++ b/astro-site/src/content/docs/rules/R_planetary_shield.md
@@ -30,9 +30,9 @@ Units cannot use the Bombardment ability against a planet that contains a unit t
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Bombardment](r_bombardment)
- - [Invasion](r_invasion)
- - [PDS](r_pds)
+ - [Abilities](../r_abilities)
+ - [Bombardment](../r_bombardment)
+ - [Invasion](../r_invasion)
+ - [PDS](../r_pds)
  
  

--- a/astro-site/src/content/docs/rules/R_planets.md
+++ b/astro-site/src/content/docs/rules/R_planets.md
@@ -37,16 +37,16 @@ Each planet has a corresponding planet card that displays its name, resource val
 ## Related Topics
 
  
- - [Control](r_control)
- - [Exploration](r_exploration)
- - [Exhausted](r_exhausted)
- - [Influence](r_influence)
- - [Invasion](r_invasion)
- - [Legendary Planets](r_legendary_planets)
- - [Mecatol Rex](r_mecatol_rex)
- - [Readied](r_readied)
- - [Resources](r_resources)
- - [System Tiles](r_system_tiles)
- - [Technology](r_technology)
+ - [Control](../r_control)
+ - [Exploration](../r_exploration)
+ - [Exhausted](../r_exhausted)
+ - [Influence](../r_influence)
+ - [Invasion](../r_invasion)
+ - [Legendary Planets](../r_legendary_planets)
+ - [Mecatol Rex](../r_mecatol_rex)
+ - [Readied](../r_readied)
+ - [Resources](../r_resources)
+ - [System Tiles](../r_system_tiles)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_politics.md
+++ b/astro-site/src/content/docs/rules/R_politics.md
@@ -29,11 +29,11 @@ The <i>Politics</i> strategy card allows players to draw action cards. Additiona
 ## Related Topics
 
  
- - [Action Cards](r_action_cards)
- - [Agenda Card](r_agenda_card)
- - [Initiative Order](r_initiative_order)
- - [Speaker](r_speaker)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
+ - [Action Cards](../r_action_cards)
+ - [Agenda Card](../r_agenda_card)
+ - [Initiative Order](../r_initiative_order)
+ - [Speaker](../r_speaker)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
  
  

--- a/astro-site/src/content/docs/rules/R_producing_units.md
+++ b/astro-site/src/content/docs/rules/R_producing_units.md
@@ -49,16 +49,16 @@ The primary way that a player produces new units is by resolving the Production 
 ## Related Topics
 
  
- - [Blockaded](r_blockaded)
- - [Component Limitations](r_component_limitations)
- - [Cost](r_cost)
- - [Fighter Tokens](r_fighter_tokens)
- - [Infantry Tokens](r_infantry_tokens)
- - [Production](r_production)
- - [Resources](r_resources)
- - [Space Dock](r_space_dock)
- - [Tactical Action](r_tactical_action)
- - [Units](r_units)
- - [Warfare](r_warfare)
+ - [Blockaded](../r_blockaded)
+ - [Component Limitations](../r_component_limitations)
+ - [Cost](../r_cost)
+ - [Fighter Tokens](../r_fighter_tokens)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Production](../r_production)
+ - [Resources](../r_resources)
+ - [Space Dock](../r_space_dock)
+ - [Tactical Action](../r_tactical_action)
+ - [Units](../r_units)
+ - [Warfare](../r_warfare)
  
  

--- a/astro-site/src/content/docs/rules/R_production.md
+++ b/astro-site/src/content/docs/rules/R_production.md
@@ -35,12 +35,12 @@ During the <b>Production</b> step of a tactical action, the active player can re
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Blockaded](r_blockaded)
- - [Producing Units](r_producing_units)
- - [Resources](r_resources)
- - [Space Dock](r_space_dock)
- - [Units](r_units)
- - [Warfare](r_warfare)
+ - [Abilities](../r_abilities)
+ - [Blockaded](../r_blockaded)
+ - [Producing Units](../r_producing_units)
+ - [Resources](../r_resources)
+ - [Space Dock](../r_space_dock)
+ - [Units](../r_units)
+ - [Warfare](../r_warfare)
  
  

--- a/astro-site/src/content/docs/rules/R_promissory_notes.md
+++ b/astro-site/src/content/docs/rules/R_promissory_notes.md
@@ -47,9 +47,9 @@ Each player begins the game with one unique and five generic promissory note car
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Component Action](r_component_action)
- - [Elimination](r_elimination)
- - [Transactions](r_transactions)
+ - [Abilities](../r_abilities)
+ - [Component Action](../r_component_action)
+ - [Elimination](../r_elimination)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_purge.md
+++ b/astro-site/src/content/docs/rules/R_purge.md
@@ -22,9 +22,9 @@ Purge is a cost that permanently removes a component from the game. If an abilit
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Exploration](r_exploration)
- - [Leaders](r_leaders)
- - [Relics](r_relics)
+ - [Abilities](../r_abilities)
+ - [Exploration](../r_exploration)
+ - [Leaders](../r_leaders)
+ - [Relics](../r_relics)
  
  

--- a/astro-site/src/content/docs/rules/R_readied.md
+++ b/astro-site/src/content/docs/rules/R_readied.md
@@ -34,13 +34,13 @@ Cards have a readied state, which indicates that a player can exhaust or resolve
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Diplomacy](r_diplomacy)
- - [Exhausted](r_exhausted)
- - [Leaders](r_leaders)
- - [Planets](r_planets)
- - [Relics](r_relics)
- - [Status Phase](r_status_phase)
- - [Technology](r_technology)
+ - [Abilities](../r_abilities)
+ - [Diplomacy](../r_diplomacy)
+ - [Exhausted](../r_exhausted)
+ - [Leaders](../r_leaders)
+ - [Planets](../r_planets)
+ - [Relics](../r_relics)
+ - [Status Phase](../r_status_phase)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_reinforcements.md
+++ b/astro-site/src/content/docs/rules/R_reinforcements.md
@@ -23,9 +23,9 @@ A player’s reinforcements is that player’s personal supply of units and comm
 ## Related Topics
 
  
- - [Command Tokens](r_command_tokens)
- - [Component Limitations](r_component_limitations)
- - [Deploy](r_deploy)
- - [Units](r_units)
+ - [Command Tokens](../r_command_tokens)
+ - [Component Limitations](../r_component_limitations)
+ - [Deploy](../r_deploy)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_relics.md
+++ b/astro-site/src/content/docs/rules/R_relics.md
@@ -32,11 +32,11 @@ Relics are powerful artifacts with unique abilities.
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Component Action](r_component_action)
- - [Exhausted](r_exhausted)
- - [Exploration](r_exploration)
- - [Purge](r_purge)
- - [Readied](r_readied)
+ - [Abilities](../r_abilities)
+ - [Component Action](../r_component_action)
+ - [Exhausted](../r_exhausted)
+ - [Exploration](../r_exploration)
+ - [Purge](../r_purge)
+ - [Readied](../r_readied)
  
  

--- a/astro-site/src/content/docs/rules/R_rerolls.md
+++ b/astro-site/src/content/docs/rules/R_rerolls.md
@@ -23,10 +23,10 @@ Some game effects instruct a player to reroll dice.
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Anti–Fighter Barrage](r_anti_fighter_barrage)
- - [Bombardment](r_bombardment)
- - [Combat](r_combat)
- - [Space Cannon](r_space_cannon)
+ - [Abilities](../r_abilities)
+ - [Anti–Fighter Barrage](../r_anti_fighter_barrage)
+ - [Bombardment](../r_bombardment)
+ - [Combat](../r_combat)
+ - [Space Cannon](../r_space_cannon)
  
  

--- a/astro-site/src/content/docs/rules/R_resources.md
+++ b/astro-site/src/content/docs/rules/R_resources.md
@@ -22,11 +22,11 @@ Resources represent a planet’s material value and industry. Many game effects,
 ## Related Topics
 
  
- - [Cost](r_cost)
- - [Exhausted](r_exhausted)
- - [Planets](r_planets)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Trade Goods](r_trade_goods)
+ - [Cost](../r_cost)
+ - [Exhausted](../r_exhausted)
+ - [Planets](../r_planets)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Trade Goods](../r_trade_goods)
  
  

--- a/astro-site/src/content/docs/rules/R_ships.md
+++ b/astro-site/src/content/docs/rules/R_ships.md
@@ -26,13 +26,13 @@ A ship is a unit type consisting of carriers, cruisers, dreadnoughts, destroyers
 ## Related Topics
 
  
- - [Capacity](r_capacity)
- - [Combat](r_combat)
- - [Cost](r_cost)
- - [Fleet Pool](r_fleet_pool)
- - [Move](r_move)
- - [Movement](r_movement)
- - [Space Combat](r_space_combat)
- - [Units](r_units)
+ - [Capacity](../r_capacity)
+ - [Combat](../r_combat)
+ - [Cost](../r_cost)
+ - [Fleet Pool](../r_fleet_pool)
+ - [Move](../r_move)
+ - [Movement](../r_movement)
+ - [Space Combat](../r_space_combat)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_space_cannon.md
+++ b/astro-site/src/content/docs/rules/R_space_cannon.md
@@ -65,14 +65,14 @@ During the invasion step of a tactical action, after ground forces have been com
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Active Player](r_active_player)
- - [Active System](r_active_system)
- - [Adjacency](r_adjacency)
- - [Destroyed](r_destroyed)
- - [Invasion](r_invasion)
- - [Movement](r_movement)
- - [PDS](r_pds)
- - [Sustain Damage](r_sustain_damage)
+ - [Abilities](../r_abilities)
+ - [Active Player](../r_active_player)
+ - [Active System](../r_active_system)
+ - [Adjacency](../r_adjacency)
+ - [Destroyed](../r_destroyed)
+ - [Invasion](../r_invasion)
+ - [Movement](../r_movement)
+ - [PDS](../r_pds)
+ - [Sustain Damage](../r_sustain_damage)
  
  

--- a/astro-site/src/content/docs/rules/R_space_combat.md
+++ b/astro-site/src/content/docs/rules/R_space_combat.md
@@ -73,7 +73,7 @@ To resolve a space combat, players perform the following steps:
     1. The Empyrean player may retreat into a nebula.
     2. The <i>Shared Research</i> law will not allow a player to retreat into a nebula.
  
-5. A player may attempt to retreat from a combat in a gravity rift, but will still be affected by it. See the [gravity rift page](r_gravity_rift) for more details.
+5. A player may attempt to retreat from a combat in a gravity rift, but will still be affected by it. See the [gravity rift page](../r_gravity_rift) for more details.
 6. If a player only has fighters I in the combat when they retreat, those will be removed from the board, and they will not place a command token in an adjacent system.
 7. The <i>Nav Suite</i> action card will not allow a player to ignore an anomaly while retreating.
 8. The <i>Dark Energy Tap</i> technology allows a player to retreat into a system that does not contain their ships or a planet they control.
@@ -91,14 +91,14 @@ To resolve a space combat, players perform the following steps:
 ## Related Topics
 
  
- - [Anti–Fighter Barrage](r_anti_fighter_barrage)
- - [Attacker](r_attacker)
- - [Capacity](r_capacity)
- - [Defender](r_defender)
- - [Destroyed](r_destroyed)
- - [Fleet Pool](r_fleet_pool)
- - [Opponent](r_opponent)
- - [Sustain Damage](r_sustain_damage)
- - [Tactical Action](r_tactical_action)
+ - [Anti–Fighter Barrage](../r_anti_fighter_barrage)
+ - [Attacker](../r_attacker)
+ - [Capacity](../r_capacity)
+ - [Defender](../r_defender)
+ - [Destroyed](../r_destroyed)
+ - [Fleet Pool](../r_fleet_pool)
+ - [Opponent](../r_opponent)
+ - [Sustain Damage](../r_sustain_damage)
+ - [Tactical Action](../r_tactical_action)
  
  

--- a/astro-site/src/content/docs/rules/R_space_dock.md
+++ b/astro-site/src/content/docs/rules/R_space_dock.md
@@ -31,11 +31,11 @@ A space dock is a structure that allows players to produce units.
 ## Related Topics
 
  
- - [Blockaded](r_blockaded)
- - [Construction](r_construction)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Structures](r_structures)
- - [Warfare](r_warfare)
+ - [Blockaded](../r_blockaded)
+ - [Construction](../r_construction)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Structures](../r_structures)
+ - [Warfare](../r_warfare)
  
  

--- a/astro-site/src/content/docs/rules/R_space_stations.md
+++ b/astro-site/src/content/docs/rules/R_space_stations.md
@@ -41,13 +41,13 @@ There currently does not exist a Living Rules Reference section regarding space 
 ## Related Topics
 
  
- - [Control](r_control)
- - [Exhausted](r_exhausted)
- - [Influence](r_influence)
- - [Planets](r_planets)
- - [Readied](r_readied)
- - [Resources](r_resources)
- - [Space Combat](r_space_combat)
- - [System Tiles](r_system_tiles)
+ - [Control](../r_control)
+ - [Exhausted](../r_exhausted)
+ - [Influence](../r_influence)
+ - [Planets](../r_planets)
+ - [Readied](../r_readied)
+ - [Resources](../r_resources)
+ - [Space Combat](../r_space_combat)
+ - [System Tiles](../r_system_tiles)
  
  

--- a/astro-site/src/content/docs/rules/R_speaker.md
+++ b/astro-site/src/content/docs/rules/R_speaker.md
@@ -27,11 +27,11 @@ The speaker is the player who has the speaker token.
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Agenda Card](r_agenda_card)
- - [Agenda Phase](r_agenda_phase)
- - [Objective Cards](r_objective_cards)
- - [Politics](r_politics)
- - [Strategy Phase](r_strategy_phase)
+ - [Abilities](../r_abilities)
+ - [Agenda Card](../r_agenda_card)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Objective Cards](../r_objective_cards)
+ - [Politics](../r_politics)
+ - [Strategy Phase](../r_strategy_phase)
  
  

--- a/astro-site/src/content/docs/rules/R_status_phase.md
+++ b/astro-site/src/content/docs/rules/R_status_phase.md
@@ -38,16 +38,16 @@ During the status phase, players score objectives and prepare for the next game 
 ## Related Topics
 
  
- - [Action Cards](r_action_cards)
- - [Agenda Phase](r_agenda_phase)
- - [Custodians Token](r_custodians_token)
- - [Command Tokens](r_command_tokens)
- - [Game Round](r_game_round)
- - [Initiative Order](r_initiative_order)
- - [Objective Cards](r_objective_cards)
- - [Readied](r_readied)
- - [Strategy Card](r_strategy_card)
- - [Sustain Damage](r_sustain_damage)
- - [Victory Points](r_victory_points)
+ - [Action Cards](../r_action_cards)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Custodians Token](../r_custodians_token)
+ - [Command Tokens](../r_command_tokens)
+ - [Game Round](../r_game_round)
+ - [Initiative Order](../r_initiative_order)
+ - [Objective Cards](../r_objective_cards)
+ - [Readied](../r_readied)
+ - [Strategy Card](../r_strategy_card)
+ - [Sustain Damage](../r_sustain_damage)
+ - [Victory Points](../r_victory_points)
  
  

--- a/astro-site/src/content/docs/rules/R_strategic_action.md
+++ b/astro-site/src/content/docs/rules/R_strategic_action.md
@@ -28,7 +28,7 @@ During the action phase, the active player may perform a strategic action to res
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Strategy Card](r_strategy_card)
+ - [Action Phase](../r_action_phase)
+ - [Strategy Card](../r_strategy_card)
  
  

--- a/astro-site/src/content/docs/rules/R_strategy_card.md
+++ b/astro-site/src/content/docs/rules/R_strategy_card.md
@@ -39,16 +39,16 @@ Strategy cards determine initiative order and provide each player with a powerfu
 ## Related Topics
 
  
- - [Construction](r_construction)
- - [Diplomacy](r_diplomacy)
- - [Imperial](r_imperial)
- - [Initiative Order](r_initiative_order)
- - [Leadership](r_leadership)
- - [Politics](r_politics)
- - [Strategic Action](r_strategic_action)
- - [Strategy Phase](r_strategy_phase)
- - <a href="/rules/r_technology_sc">Technology (<abbr title="Strategy Card">S.C.</abbr>)</sub></a>
- - [Trade](r_trade)
- - [Warfare](r_warfare)
+ - [Construction](../r_construction)
+ - [Diplomacy](../r_diplomacy)
+ - [Imperial](../r_imperial)
+ - [Initiative Order](../r_initiative_order)
+ - [Leadership](../r_leadership)
+ - [Politics](../r_politics)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Phase](../r_strategy_phase)
+ - [Technology (<abbr title="Strategy Card">S.C.</abbr>)](../r_technology_sc)
+ - [Trade](../r_trade)
+ - [Warfare](../r_warfare)
  
  

--- a/astro-site/src/content/docs/rules/R_strategy_phase.md
+++ b/astro-site/src/content/docs/rules/R_strategy_phase.md
@@ -36,10 +36,10 @@ Then, players proceed to the action phase.
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Game Round](r_game_round)
- - [Speaker](r_speaker)
- - [Strategy Card](r_strategy_card)
- - [Trade Goods](r_trade_goods)
+ - [Action Phase](../r_action_phase)
+ - [Game Round](../r_game_round)
+ - [Speaker](../r_speaker)
+ - [Strategy Card](../r_strategy_card)
+ - [Trade Goods](../r_trade_goods)
  
  

--- a/astro-site/src/content/docs/rules/R_structures.md
+++ b/astro-site/src/content/docs/rules/R_structures.md
@@ -28,9 +28,9 @@ A structure is a type of unit. PDS units and space docks are structures.
 ## Related Topics
 
  
- - [Construction](r_construction)
- - [Space Dock](r_space_dock)
- - [PDS](r_pds)
- - [Units](r_units)
+ - [Construction](../r_construction)
+ - [Space Dock](../r_space_dock)
+ - [PDS](../r_pds)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_supernova.md
+++ b/astro-site/src/content/docs/rules/R_supernova.md
@@ -22,7 +22,7 @@ A supernova is an anomaly that affects movement.
 ## Related Topics
 
  
- - [Anomalies](r_anomalies)
- - [Movement](r_movement)
+ - [Anomalies](../r_anomalies)
+ - [Movement](../r_movement)
  
  

--- a/astro-site/src/content/docs/rules/R_sustain_damage.md
+++ b/astro-site/src/content/docs/rules/R_sustain_damage.md
@@ -28,12 +28,12 @@ Some units have the Sustain Damage ability. Immediately before a player assigns 
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Anti–Fighter Barrage](r_anti_fighter_barrage)
- - [Bombardment](r_bombardment)
- - [Destroyed](r_destroyed)
- - [Ground Combat](r_ground_combat)
- - [Space Combat](r_space_combat)
- - [Status Phase](r_status_phase)
+ - [Abilities](../r_abilities)
+ - [Anti–Fighter Barrage](../r_anti_fighter_barrage)
+ - [Bombardment](../r_bombardment)
+ - [Destroyed](../r_destroyed)
+ - [Ground Combat](../r_ground_combat)
+ - [Space Combat](../r_space_combat)
+ - [Status Phase](../r_status_phase)
  
  

--- a/astro-site/src/content/docs/rules/R_synergy.md
+++ b/astro-site/src/content/docs/rules/R_synergy.md
@@ -32,6 +32,6 @@ There currently does not exist a Living Rules Reference section regarding synerg
 ## Related Topics
 
  
- - [Breakthroughs](r_breakthroughs)
+ - [Breakthroughs](../r_breakthroughs)
  
  

--- a/astro-site/src/content/docs/rules/R_system_tiles.md
+++ b/astro-site/src/content/docs/rules/R_system_tiles.md
@@ -26,12 +26,12 @@ A system tile represents an area of the galaxy. Players place system tiles durin
 ## Related Topics
 
  
- - [Active System](r_active_system)
- - [Adjacency](r_adjacency)
- - [Anomalies](r_anomalies)
- - [Game Board](r_game_board)
- - [Hyperlanes](r_hyperlanes)
- - [Planets](r_planets)
- - [Wormholes](r_wormholes)
+ - [Active System](../r_active_system)
+ - [Adjacency](../r_adjacency)
+ - [Anomalies](../r_anomalies)
+ - [Game Board](../r_game_board)
+ - [Hyperlanes](../r_hyperlanes)
+ - [Planets](../r_planets)
+ - [Wormholes](../r_wormholes)
  
  

--- a/astro-site/src/content/docs/rules/R_tactical_action.md
+++ b/astro-site/src/content/docs/rules/R_tactical_action.md
@@ -41,14 +41,14 @@ The tactical action is the primary method by which players produce units, move s
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Active System](r_active_system)
- - [Command Sheet](r_command_sheet)
- - [Command Tokens](r_command_tokens)
- - [Invasion](r_invasion)
- - [Movement](r_movement)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Space Combat](r_space_combat)
+ - [Action Phase](../r_action_phase)
+ - [Active System](../r_active_system)
+ - [Command Sheet](../r_command_sheet)
+ - [Command Tokens](../r_command_tokens)
+ - [Invasion](../r_invasion)
+ - [Movement](../r_movement)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Space Combat](../r_space_combat)
  
  

--- a/astro-site/src/content/docs/rules/R_technology.md
+++ b/astro-site/src/content/docs/rules/R_technology.md
@@ -81,11 +81,11 @@ The Nekro Virus faction can use its faction abilities in combination with its tw
 ## Related Topics
 
  
- - [Abilities](r_abilities)
- - [Component Action](r_component_action)
- - [Exhausted](r_exhausted)
- - [Readied](r_readied)
- - <a href="/rules/r_technology_sc">Technology (<abbr title="Strategy Card">S.C.</abbr>)</sub></a>
- - [Unit Upgrades](r_unit_upgrades)
+ - [Abilities](../r_abilities)
+ - [Component Action](../r_component_action)
+ - [Exhausted](../r_exhausted)
+ - [Readied](../r_readied)
+ - [Technology (<abbr title="Strategy Card">S.C.</abbr>)](../r_technology_sc)
+ - [Unit Upgrades](../r_unit_upgrades)
  
  

--- a/astro-site/src/content/docs/rules/R_technology_sc.md
+++ b/astro-site/src/content/docs/rules/R_technology_sc.md
@@ -22,11 +22,11 @@ The <i>Technology</i> strategy card allows players to research new technology. T
 ## Related Topics
 
  
- - [Command Tokens](r_command_tokens)
- - [Initiative Order](r_initiative_order)
- - [Resources](r_resources)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
- - [Technology](r_technology)
+ - [Command Tokens](../r_command_tokens)
+ - [Initiative Order](../r_initiative_order)
+ - [Resources](../r_resources)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
+ - [Technology](../r_technology)
  
  

--- a/astro-site/src/content/docs/rules/R_trade.md
+++ b/astro-site/src/content/docs/rules/R_trade.md
@@ -46,11 +46,11 @@ A deal made during a given step is non–binding if any part of it is to resolve
 ## Related Topics
 
  
- - [Command Tokens](r_command_tokens)
- - [Commodities](r_commodities)
- - [Initiative Order](r_initiative_order)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
- - [Trade Goods](r_trade_goods)
+ - [Command Tokens](../r_command_tokens)
+ - [Commodities](../r_commodities)
+ - [Initiative Order](../r_initiative_order)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
+ - [Trade Goods](../r_trade_goods)
  
  

--- a/astro-site/src/content/docs/rules/R_trade_goods.md
+++ b/astro-site/src/content/docs/rules/R_trade_goods.md
@@ -34,12 +34,12 @@ A trade good represents a player’s buying and trading power beyond their plane
 ## Related Topics
 
  
- - [Command Sheet](r_command_sheet)
- - [Commodities](r_commodities)
- - [Deals](r_deals)
- - [Influence](r_influence)
- - [Resources](r_resources)
- - [Trade](r_trade)
- - [Transactions](r_transactions)
+ - [Command Sheet](../r_command_sheet)
+ - [Commodities](../r_commodities)
+ - [Deals](../r_deals)
+ - [Influence](../r_influence)
+ - [Resources](../r_resources)
+ - [Trade](../r_trade)
+ - [Transactions](../r_transactions)
  
  

--- a/astro-site/src/content/docs/rules/R_transactions.md
+++ b/astro-site/src/content/docs/rules/R_transactions.md
@@ -46,14 +46,14 @@ A transaction is a way for a player to exchange commodities, trade goods, promis
 ## Related Topics
 
  
- - [Active Player](r_active_player)
- - [Agenda Phase](r_agenda_phase)
- - [Capture](r_capture)
- - [Commodities](r_commodities)
- - [Exploration](r_exploration)
- - [Deals](r_deals)
- - [Neighbors](r_neighbors)
- - [Promissory Notes](r_promissory_notes)
- - [Trade Goods](r_trade_goods)
+ - [Active Player](../r_active_player)
+ - [Agenda Phase](../r_agenda_phase)
+ - [Capture](../r_capture)
+ - [Commodities](../r_commodities)
+ - [Exploration](../r_exploration)
+ - [Deals](../r_deals)
+ - [Neighbors](../r_neighbors)
+ - [Promissory Notes](../r_promissory_notes)
+ - [Trade Goods](../r_trade_goods)
  
  

--- a/astro-site/src/content/docs/rules/R_transport.md
+++ b/astro-site/src/content/docs/rules/R_transport.md
@@ -40,8 +40,8 @@ When a ship moves, it may transport any combination of fighters and ground force
 ## Related Topics
 
  
- - [Capacity](r_capacity)
- - [Ground Forces](r_ground_forces)
- - [Movement](r_movement)
+ - [Capacity](../r_capacity)
+ - [Ground Forces](../r_ground_forces)
+ - [Movement](../r_movement)
  
  

--- a/astro-site/src/content/docs/rules/R_unit_upgrades.md
+++ b/astro-site/src/content/docs/rules/R_unit_upgrades.md
@@ -30,7 +30,7 @@ A unit upgrade is a type of technology card.
 ## Related Topics
 
  
- - [Technology](r_technology)
- - [Units](r_units)
+ - [Technology](../r_technology)
+ - [Units](../r_units)
  
  

--- a/astro-site/src/content/docs/rules/R_units.md
+++ b/astro-site/src/content/docs/rules/R_units.md
@@ -40,15 +40,15 @@ A unit is represented by a plastic figure.
 ## Related Topics
 
  
- - [Component Limitations](r_component_limitations)
- - [Fighter Tokens](r_fighter_tokens)
- - [Ground Forces](r_ground_forces)
- - [Infantry Tokens](r_infantry_tokens)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Reinforcements](r_reinforcements)
- - [Ships](r_ships)
- - [Structures](r_structures)
- - [Unit Upgrades](r_unit_upgrades)
+ - [Component Limitations](../r_component_limitations)
+ - [Fighter Tokens](../r_fighter_tokens)
+ - [Ground Forces](../r_ground_forces)
+ - [Infantry Tokens](../r_infantry_tokens)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Reinforcements](../r_reinforcements)
+ - [Ships](../r_ships)
+ - [Structures](../r_structures)
+ - [Unit Upgrades](../r_unit_upgrades)
  
  

--- a/astro-site/src/content/docs/rules/R_victory_points.md
+++ b/astro-site/src/content/docs/rules/R_victory_points.md
@@ -33,9 +33,9 @@ The first player to gain 10 victory points wins the game.
 ## Related Topics
 
  
- - [Agenda Card](r_agenda_card)
- - [Imperial](r_imperial)
- - [Objective Cards](r_objective_cards)
- - [Relics](r_relics)
+ - [Agenda Card](../r_agenda_card)
+ - [Imperial](../r_imperial)
+ - [Objective Cards](../r_objective_cards)
+ - [Relics](../r_relics)
  
  

--- a/astro-site/src/content/docs/rules/R_warfare.md
+++ b/astro-site/src/content/docs/rules/R_warfare.md
@@ -29,14 +29,14 @@ To resolve the primary ability on the <i>Warfare</i> strategy card, the active p
 ## Related Topics
 
  
- - [Action Phase](r_action_phase)
- - [Command Sheet](r_command_sheet)
- - [Command Tokens](r_command_tokens)
- - [Initiative Order](r_initiative_order)
- - [Producing Units](r_producing_units)
- - [Production](r_production)
- - [Space Dock](r_space_dock)
- - [Strategic Action](r_strategic_action)
- - [Strategy Card](r_strategy_card)
+ - [Action Phase](../r_action_phase)
+ - [Command Sheet](../r_command_sheet)
+ - [Command Tokens](../r_command_tokens)
+ - [Initiative Order](../r_initiative_order)
+ - [Producing Units](../r_producing_units)
+ - [Production](../r_production)
+ - [Space Dock](../r_space_dock)
+ - [Strategic Action](../r_strategic_action)
+ - [Strategy Card](../r_strategy_card)
  
  

--- a/astro-site/src/content/docs/rules/R_wormhole_nexus.md
+++ b/astro-site/src/content/docs/rules/R_wormhole_nexus.md
@@ -34,8 +34,8 @@ The wormhole nexus is a system tile where several wormholes converge.
 ## Related Topics
 
  
- - [Movement](r_movement)
- - [System Tiles](r_system_tiles)
- - [Wormholes](r_wormholes)
+ - [Movement](../r_movement)
+ - [System Tiles](../r_system_tiles)
+ - [Wormholes](../r_wormholes)
  
  

--- a/astro-site/src/content/docs/rules/R_wormholes.md
+++ b/astro-site/src/content/docs/rules/R_wormholes.md
@@ -37,10 +37,10 @@ Some systems contain wormholes. Systems that contain identical wormholes are adj
 ## Related Topics
 
  
- - [Adjacency](r_adjacency)
- - [Movement](r_movement)
- - [Neighbors](r_neighbors)
- - [System Tiles](r_system_tiles)
- - [Wormhole Nexus](r_wormhole_nexus)
+ - [Adjacency](../r_adjacency)
+ - [Movement](../r_movement)
+ - [Neighbors](../r_neighbors)
+ - [System Tiles](../r_system_tiles)
+ - [Wormhole Nexus](../r_wormhole_nexus)
  
  


### PR DESCRIPTION
- Updated markdown links to ensure correct relative paths for related topics across various rule files.
- Normalized link targets to lowercase and cleaned up stray HTML tags in link text.
- Added a script to automate the fixing of broken links and validate link targets against existing content files.

Closes #2 